### PR TITLE
Change repository name and change homepage path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "homepage":"http://luizalsc.github.io/Pokedex-React",
   "name": "pokedex",
   "version": "0.1.0",
   "private": true,

--- a/src/pages/routes.js
+++ b/src/pages/routes.js
@@ -1,16 +1,16 @@
-import { BrowserRouter, Route, Routes, HashRouter } from 'react-router-dom'
+import {  Route, Routes, BrowserRouter } from 'react-router-dom'
 import { Pokemons } from './pokemons'
 import { Pokemon } from './pokemon'
 
 
 const AppRoutes =() => {
     return(
-        <HashRouter>
+        <BrowserRouter basename={process.env.PUBLIC_URL}>
             <Routes>
                 <Route exact path='/' element={<Pokemons/>}/>
                 <Route exact path='/pokemons/:id' element={<Pokemon/>}/>
             </Routes>
-        </HashRouter>
+        </BrowserRouter>
     )
 }
 


### PR DESCRIPTION
The previous repository ("Quest_React_Avancado_Pokedex") name was blocking the homepage path from being read, the name was changed excluding any underlines, and the path at package.json was modified to "http://luizalsc.github.io/Pokedex-React", with that the deploy was possible and no more issues apeared.